### PR TITLE
Changes for integrating with Noetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ find_package(
 
 ## Add find-modules and define external dependencies
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-find_package(Boost REQUIRED COMPONENTS system python)
+find_package(Python REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system python${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
 find_package(Eigen3 REQUIRED)
 find_package(PythonLibs REQUIRED)
 find_package(Bullet REQUIRED)

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -39,8 +39,8 @@
 #include <occupancy_grid_utils/file.h>
 #include <tf/transform_datatypes.h>
 #include <nav_msgs/GetMap.h>
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/highgui.hpp>
 
 namespace occupancy_grid_utils
 {
@@ -61,9 +61,9 @@ namespace gm=geometry_msgs;
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <opencv2/opencv.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/highgui.hpp>
 
 #include "LinearMath/btMatrix3x3.h"
 
@@ -89,7 +89,7 @@ loadMapFromFile(nav_msgs::GetMap::Response* resp,
               fname + std::string("\"");
       throw std::runtime_error(errmsg);
   }
-  cvtColor(imgColor, img, cv::BGR2GRAY);
+  cvtColor(imgColor, img, cv::COLOR_BGR2GRAY);
 
   // Copy the image data into the map structure
   resp->map.info.width = img.rows;


### PR DESCRIPTION
This PR contains some modifications for integrating the package with ROS Noetic, namely:
* Modifying OpenCV imports `cvtColor` function call to support version 4.2.0 (focal/noetic native)
* Configuring the Boost python package import according to system Python version (3.8 for noetic). Otherwise, it expects Python 2.7 by default, and would fail to build